### PR TITLE
Tweak prototype declaration so objects don't share an instance.

### DIFF
--- a/lib/recaptcha.js
+++ b/lib/recaptcha.js
@@ -41,7 +41,7 @@ function reCaptcha()
 	this._recaptcha_response = { 'is_valid': false, 'error': 'incorrect-captcha-sol' };
 	return this;
 }
-reCaptcha.prototype = new EventEmitter();
+reCaptcha.prototype.__proto__ = EventEmitter.prototype;
 
 /**
  * Makes a HTTP POST request to the reCaptcha server to verify if the user's guess was correct.


### PR DESCRIPTION
If you create multiple instances of reCaptcha and bind different (or the same) handlers with `on`, all of them will get triggered when even a single one of the instances is asked to check, because they share a single `EventEmitter` instance in their prototype.